### PR TITLE
Correct search images for several "all these tags"

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -149,12 +149,14 @@ SELECT *
           case 'all':
           {
             $tags_arr = explode(',', $filter['value']);
+            $tags_where = array() ;
             foreach ($tags_arr as $value)
             {
               $join[] = IMAGE_TAG_TABLE.' AS it'.$i_tags.' ON i.id = it'.$i_tags.'.image_id';
-              $where[] = 'it'.$i_tags.'.tag_id = '.$value;
+              $tags_where[] = 'it'.$i_tags.'.tag_id = '.$value;
               $i_tags++;
             }
+            $where[] = '('.implode(' and ', $tags_where).')' ;
 
             break;
           }


### PR DESCRIPTION
When filter second radio is checked "Photos must match at least one filter" (OR) and a pair of "All these tags" (AND) is set. The first with tag1a AND tag1b, and the second with tag2a AND tag2b. I expect the SQL WHERE to be somehow like (tag1a AND tag1b) OR (tag2a AND tag2b).
That is a correction for 'all' case block.

NB : I wonder if 'only' case can be affected by the same mistake.